### PR TITLE
fix command eating prompt when it ends the current line

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -2,6 +2,8 @@
 # define MINISHELL_H
 # define MAX_ARGS 1024
 
+#define PROMPT "\001\e[0m\e[33m\002minishell$ \001\e[0m\002"
+
 # include <stdio.h>
 # include <stdlib.h>
 # include <unistd.h>
@@ -95,7 +97,7 @@ char		*expand_variables(const char *str,
 				t_quotes quote_type, char **envp);
 int			is_special(char c);
 int			is_quote(char c);
-char		*read_multiline_command(char *prompt);
+char *read_multiline_command(void);
 //help variables
 char		*append_str(char *base, const char *add);
 char		*is_var_name(const char *str, int *len);

--- a/src/executor/get_input_and_free.c
+++ b/src/executor/get_input_and_free.c
@@ -32,20 +32,9 @@ void free_cmd_list(t_cmd_node *cmds)
 
 char *get_input(t_prompt *prompt)
 {
-	char *cwd;
-	char *prompt_str;
 	char *input;
 
-	cwd = get_env_var_value("PWD", prompt->envp);
-	if (cwd)
-		prompt_str = ft_strjoin("\033[0;32mminishell> \033[0;34m", cwd);
-	else
-		prompt_str = ft_strdup("\033[0;32mminishell> \033[0m");
-	char *tmp = prompt_str;
-	prompt_str = ft_strjoin(tmp, "\033[0m $ ");
-	free(tmp);
-	input = read_multiline_command(prompt_str);
-	free(prompt_str);
+	input = read_multiline_command();
 	if (!input)
 	{
 		printf("exit\n");

--- a/src/parsing/helper_parse.c
+++ b/src/parsing/helper_parse.c
@@ -20,13 +20,13 @@ static int quotes_are_closed(const char *str)
 	return (single % 2 == 0 && dbl % 2 == 0);
 }
 
-char *read_multiline_command(char *prompt)
+char *read_multiline_command(void)
 {
 	char *line;
 	char *full_line;
 	char *tmp;
 
-	line = readline(prompt);
+	line = readline(PROMPT);
 	set_signals_noninteractive();
 	if (!line)
 		return (NULL);

--- a/todo.md
+++ b/todo.md
@@ -1,12 +1,5 @@
-DONE fix relative paths, if a relative path is sent, dont try to search it inside $PATH, just try to execute it (Mario)
-DONE make a function that inits all the crutial env variables if minishell is initd with an empty envp (Mario)
-DONE unsetting PATH and trying to use command without abs/relative paths will result in core dumped, instead just ignore all non abs/relative and non builtin command calls (Mario)
-
 TODO export with double or single quotes does not work (Mario)
 TODO make all procs return values match with bash (Mario)
 
-TODO update the $PWD each time cd is used
-TODO fix double print of prompt when ctrl+c is used when a command is listening to stdin eg: cat
 TODO fix memory leaks
-TODO ctrl+\ after running a blocking command like cat without args should exit the shell and return 131
 TODO if the line its too long it will start eating the prompt from the other side, make it so that it jumps to the next line instead


### PR DESCRIPTION
This is the look of the new prompt: 
<img width="188" height="65" alt="screenshot_2025-07-22_18-57-32" src="https://github.com/user-attachments/assets/33f0da89-bf3d-47dd-ae8a-49621ee0432c" />
fixed: 
<img width="1249" height="145" alt="screenshot_2025-07-22_18-58-48" src="https://github.com/user-attachments/assets/3ee323be-9782-4573-8fb1-842d1961b634" />

